### PR TITLE
Reduced MTU to 1300 to support NordVPN.

### DIFF
--- a/Runtime/NetworkParams.cs
+++ b/Runtime/NetworkParams.cs
@@ -44,7 +44,9 @@ namespace Unity.Networking.Transport
         /// <summary>
         /// The max size of any packet that can be sent
         /// </summary>
-        public const int MTU = 1400;
+        public const int MTU = 1300; // OOI_CC - The default is 1400, but this wouldn't work on NordVPN. After talking to some Unity reps on Discord, the solution
+                                     //          arrived at was to lower this value. Testing confirmed this worked. It does mean we have slightly worse bandwidth
+                                     //          use now, but it seems there's not really a solid number to choose that fits all scenarios.
     }
 
     /// <summary>


### PR DESCRIPTION
See conversation starting here on Discord - https://discord.com/channels/449263083769036810/1067070048830771200/1092846833207869531

If that's gone in future, the TLDR; is that there's no one exact number that works across the board here, and 1400 is clearly too high for NordVPN. I was able to get it to work at 1390 but decided to reduce it to 1300 to give a bit of "buffer". Lower it is, the more supported it is but the worse bandwidth use can be.